### PR TITLE
bug by mparker17, patcon: automatically add new host key signatures, but still warn about host signature changes

### DIFF
--- a/cookbooks-override/ariadne/files/default/ssh_config
+++ b/cookbooks-override/ariadne/files/default/ssh_config
@@ -1,2 +1,4 @@
-Host github.com git.*.com
+# Still warm about IP changes, but will automatically
+# add new host key signatures.
+Host *
   StrictHostKeyChecking no


### PR DESCRIPTION
Backporting 88b942b20bedb0b8d79f8d38dafd420484a4a00a from devel to release

/cc @fluxsauce
