### PR TITLE
Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+1.3.0 (unreleased)
+------------------
+
+  - `vagrant ssh` now starts in docroot of current project.
+  - Added bash cookbook with bash\_profile resource. 
+  - Added share\_folder config to `Vagrantfile for persistent drush
+    cache between VM builds.
+
+1.2.0 (Sept. 12, 2012)
+----------------------
+
+  - Pull requests for phpunit and php were accepted, so updated
+    `Cheffile`.
+  - Moved from specifically compiled ariadne ruby to using ariadne
+    gemset.
+  - Moved to using custom percona cookbook which leverages newly tunable
+    mysql cookbook.
+  - Cleared out development gems like jenkins.rb, capistrano, etc.
+  - Removed unneeded cookbooks, particularly the database cookbook.
+  - Upgraded drush version from 5.6 to 5.7.
+  - Moved example project cookbook into standard format/location that
+    any ariadne project cookbook would use.
+  - Documented process for proper upgrade when new changes are pulled.
+  - Bumped recommended Virtualbox and RVM versions to latest in README.
+  - Upgrade host and guest chef versions from 10.12.0 to 10.14.2.
+  - Added `branch` CLI envvar to vagrant command so that ariadne
+    cookbook can implement functionality to build specific branches.
+
+1.1.0 (Sept. 10, 2012)
+----------------------
+
+  *In progres...*

--- a/Cheffile
+++ b/Cheffile
@@ -23,7 +23,7 @@ cookbook "percona",
 cookbook "php"
 cookbook "phpcs",
   :git => "https://github.com/myplanetdigital/chef-phpcs.git",
-  :ref => "v1.0.0"
+  :ref => "master"
 cookbook "phpunit",
   :git => "https://github.com/msonnabaum/chef-phpunit.git",
   :ref => "master"

--- a/Cheffile
+++ b/Cheffile
@@ -31,8 +31,8 @@ cookbook "postfix"
 cookbook "varnish"
 cookbook "vim"
 cookbook "xdebug",
-  :git => "https://github.com/myplanetdigital/chef-xdebug.git",
-  :ref => "create-logfile"
+  :git => "https://github.com/xforty/chef-xdebug.git",
+  :ref => "master"
 cookbook "xhprof",
   :git => "https://github.com/myplanetdigital/chef-xhprof.git",
   :ref => "GH-msonnabaum-3"

--- a/Cheffile
+++ b/Cheffile
@@ -5,6 +5,9 @@ site "http://community.opscode.com/api/v1"
 
 cookbook "apache2"
 cookbook "apt"
+cookbook "bash",
+  :git => "https://github.com/myplanetdigital/chef-bash.git",
+  :ref => "feature/bash_profile-resource"
 cookbook "build-essential"
 cookbook "drush",
   :git => "https://github.com/patcon/chef-drush.git",

--- a/Cheffile
+++ b/Cheffile
@@ -1,35 +1,35 @@
 #!/usr/bin/env ruby
 #^syntax detection
 
-site 'http://community.opscode.com/api/v1'
+site "http://community.opscode.com/api/v1"
 
-cookbook 'apache2'
-cookbook 'apt'
-cookbook 'build-essential'
-cookbook 'drush',
-  :git => 'https://github.com/patcon/chef-drush.git',
-  :ref => 'msonnabaum-GH-10'
-cookbook 'git'
-cookbook 'memcached'
-cookbook 'mysql',
-  :git => 'https://github.com/myplanetdigital/chef-mysql.git',
-  :ref => 'COOK-1610-bypass-preseed'
-cookbook 'percona',
-  :git => 'https://github.com/myplanetdigital/chef-percona.git',
-  :ref => 'master'
-cookbook 'php'
-cookbook 'phpcs',
-  :git => 'https://github.com/myplanetdigital/chef-phpcs.git',
-  :ref => 'v1.0.0'
-cookbook 'phpunit',
-  :git => 'https://github.com/msonnabaum/chef-phpunit.git',
-  :ref => 'master'
-cookbook 'postfix'
-cookbook 'varnish'
-cookbook 'vim'
-cookbook 'xdebug',
-  :git => 'https://github.com/myplanetdigital/chef-xdebug.git',
-  :ref => 'create-logfile'
-cookbook 'xhprof',
-  :git => 'https://github.com/myplanetdigital/chef-xhprof.git',
-  :ref => 'GH-msonnabaum-3'
+cookbook "apache2"
+cookbook "apt"
+cookbook "build-essential"
+cookbook "drush",
+  :git => "https://github.com/patcon/chef-drush.git",
+  :ref => "msonnabaum-GH-10"
+cookbook "git"
+cookbook "memcached"
+cookbook "mysql",
+  :git => "https://github.com/myplanetdigital/chef-mysql.git",
+  :ref => "COOK-1610-bypass-preseed"
+cookbook "percona",
+  :git => "https://github.com/myplanetdigital/chef-percona.git",
+  :ref => "master"
+cookbook "php"
+cookbook "phpcs",
+  :git => "https://github.com/myplanetdigital/chef-phpcs.git",
+  :ref => "v1.0.0"
+cookbook "phpunit",
+  :git => "https://github.com/msonnabaum/chef-phpunit.git",
+  :ref => "master"
+cookbook "postfix"
+cookbook "varnish"
+cookbook "vim"
+cookbook "xdebug",
+  :git => "https://github.com/myplanetdigital/chef-xdebug.git",
+  :ref => "create-logfile"
+cookbook "xhprof",
+  :git => "https://github.com/myplanetdigital/chef-xhprof.git",
+  :ref => "GH-msonnabaum-3"

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -32,6 +32,13 @@ GIT
       php (>= 0.0.0)
 
 GIT
+  remote: https://github.com/myplanetdigital/chef-bash.git
+  ref: feature/bash_profile-resource
+  sha: 1c5d2d9b110e802fe2bdab1c4c4b2ef320565292
+  specs:
+    bash (0.0.0)
+
+GIT
   remote: https://github.com/myplanetdigital/chef-mysql.git
   ref: COOK-1610-bypass-preseed
   sha: 0aba6d8ee6bc6d92406a9f66584bd0fc8dcabb4e
@@ -84,6 +91,7 @@ GIT
 DEPENDENCIES
   apache2 (>= 0)
   apt (>= 0)
+  bash (>= 0)
   build-essential (>= 0)
   drush (>= 0)
   git (>= 0)

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -50,15 +50,15 @@ GIT
 GIT
   remote: https://github.com/myplanetdigital/chef-percona.git
   ref: master
-  sha: 00f48b89a8cc3bcaab57ad0baae7e8cb2d846a1b
+  sha: d2839b8cd2d5c8ba039705f70d0d14e6a16d3fd1
   specs:
     percona (0.0.1)
       mysql (>= 1.3.0)
 
 GIT
   remote: https://github.com/myplanetdigital/chef-phpcs.git
-  ref: v1.0.0
-  sha: 50d16ac3d41adf346387183576326105c7c46540
+  ref: master
+  sha: d222847865abb4bbc40b217116433ed6419924f1
   specs:
     phpcs (1.0.0)
       php (>= 0.0.0)

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -34,7 +34,7 @@ GIT
 GIT
   remote: https://github.com/myplanetdigital/chef-bash.git
   ref: feature/bash_profile-resource
-  sha: 1c5d2d9b110e802fe2bdab1c4c4b2ef320565292
+  sha: c3fb4df4d4692ccbc27ec1df365a057a81f387ab
   specs:
     bash (0.0.0)
 

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -64,14 +64,6 @@ GIT
       php (>= 0.0.0)
 
 GIT
-  remote: https://github.com/myplanetdigital/chef-xdebug.git
-  ref: create-logfile
-  sha: cbdad80aaa9bee642d1772e945ed7c92745a2260
-  specs:
-    xdebug (0.0.1)
-      php (>= 0.0.0)
-
-GIT
   remote: https://github.com/myplanetdigital/chef-xhprof.git
   ref: GH-msonnabaum-3
   sha: 0d3690cd9e7ec1a469d30c5023130b5e2a29597d
@@ -86,6 +78,14 @@ GIT
   sha: 28d9d06fa3498b681dc4187e24321b71e14df406
   specs:
     drush (0.10.0)
+      php (>= 0.0.0)
+
+GIT
+  remote: https://github.com/xforty/chef-xdebug.git
+  ref: master
+  sha: e6745e79b451f692c56e979ab641412a6b2dacb3
+  specs:
+    xdebug (0.0.1)
       php (>= 0.0.0)
 
 DEPENDENCIES

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -43,7 +43,7 @@ GIT
 GIT
   remote: https://github.com/myplanetdigital/chef-percona.git
   ref: master
-  sha: 7a5c8301e483c9525374664c951e23eb2f310360
+  sha: 00f48b89a8cc3bcaab57ad0baae7e8cb2d846a1b
   specs:
     percona (0.0.1)
       mysql (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     archive-tar-minitar (0.5.2)
     bunny (0.7.9)
-    chef (10.14.0)
+    chef (10.14.2)
       bunny (>= 0.6.0, < 0.8.0)
       erubis
       highline (>= 1.6.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ GEM
   remote: http://rubygems.org/
   specs:
     archive-tar-minitar (0.5.2)
-    bunny (0.8.0)
-    chef (10.12.0)
-      bunny (>= 0.6.0)
+    bunny (0.7.9)
+    chef (10.14.0)
+      bunny (>= 0.6.0, < 0.8.0)
       erubis
       highline (>= 1.6.9)
       json (>= 1.4.4, <= 1.6.1)
-      mixlib-authentication (>= 1.1.0)
+      mixlib-authentication (>= 1.3.0)
       mixlib-cli (>= 1.1.0)
       mixlib-config (>= 1.1.2)
       mixlib-log (>= 1.3.0)
@@ -25,7 +25,7 @@ GEM
       ffi (~> 1.0, >= 1.0.6)
     daemons (1.1.9)
     erubis (2.7.0)
-    eventmachine (0.12.10)
+    eventmachine (1.0.0)
     ffi (1.1.5)
     highline (1.6.14)
     i18n (0.6.1)
@@ -68,7 +68,7 @@ GEM
     rubydns (0.4.1)
       eventmachine
       rexec
-    rubygems-bundler (1.0.7)
+    rubygems-bundler (1.1.0)
     systemu (2.5.2)
     thor (0.16.0)
     treetop (1.4.10)

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Requirements
 
 *Tested versions in parentheses.*
 
-  - [Virtualbox and Extension Pack][vbox-downloads] [[Note]](#note-vbox) (v4.1.18)
+  - [Virtualbox and Extension Pack][vbox-downloads] [[Note]](#note-vbox) (v4.1.22)
   - [OSX GCC Installer][about-osx-gcc-installer] [[Note]](#note-gcc-installer)
-  - [RVM][about-rvm] (v1.14.6) - Dealt with in "Quick Start" below
+  - [RVM][about-rvm] (v1.15.8) - Dealt with in "Quick Start" below
 
 For Ubuntu, you'll need to install the following packages:
 
@@ -57,8 +57,7 @@ Quick Start
 
 ### Setup
 
-    $ curl -L get.rvm.io | bash -s 1.14.6    # Install/Update RVM
-    $ exec $SHELL                            # Reloads shell
+    $ curl -L get.rvm.io | bash -s 1.15.8    # Install/Update RVM
     $ rvm reload                             # Reloads RVM
     $ git clone https://github.com/myplanetdigital/ariadne.git
     $ cd ariadne                             # rvmrc script will run
@@ -285,6 +284,15 @@ Known Issues
 
   - LogMeIn Hamachi is known to cause issues with making `pear.php.net`
     unreachable, and so the environment won't build.
+  - Sometimes you might get an error like this while running `vagrant up`:
+
+        The VM failed to remain in the "running" state while attempting to boot.
+        This is normally caused by a misconfiguration or host system incompatibilities.
+        Please open the VirtualBox GUI and attempt to boot the virtual machine
+        manually to get a more informative error message.
+
+    Should this occur, running `vagrant reload` seems to skirt the issue.
+
 
 To Do
 -----

--- a/README.md
+++ b/README.md
@@ -305,28 +305,18 @@ Known Issues
 To Do
 -----
 
-* Submit pull request to [resolve warning from
-  drush](https://github.com/myplanetdigital/ariadne/issues/9)
-* Figure out how to remove www (and subdomain) redirect from apache conf
-  template.
+https://github.com/myplanetdigital/ariadne/issues
+
 * Doc the need to refresh browser for DNS **or** run dns rake task
   first.
 * Create sister project to provide a base install profile that is
   pre-configured to use the advanced components (Memcache, Varnish,
   etc.) In progress: [2ndleveldeep][2ndleveldeep-profile]
-* Doc format that Ariadne expects for project repos, and provide a demo.
-  (It is a straightforward Chef cookbook.)
-* Create a "Development Tools" section to explain components and setup.
 * Either avoid using the confusing word "host" (vs "guest" VM) to
   describe local machine, or define terminology somewhere.
 * Add proper string support using `i18n` gem.
 * Convert to rubygem?
-* Cache downloaded Drupal modules in shared folder.
-* Generate project website from `docs/` dir like [Composer
-  does][composer-docs]
 * Convert example project to use `drush qd --no-server`.
-* Auto-detect number of cores on OSX.
-* Install Apache Solr 3.5 with Tomcat (centOS?)
 
 Contributing
 ------------
@@ -366,7 +356,6 @@ Here's the gist of how we're applying it:
    [install-oh-my-zsh]:       https://github.com/robbyrussell/oh-my-zsh#setup
    [apple-sys-arch]:          http://support.apple.com/kb/ht3773
    [2ndleveldeep-profile]:    https://github.com/myplanetdigital/2ndleveldeep#readme
-   [composer-docs]:           https://github.com/composer/composer/tree/master/doc
    [git-url-docs]:            http://git-scm.com/docs/git-clone#_git_urls
    [gitflow]:                 https://github.com/nvie/gitflow#readme
    [veewee]:                  https://github.com/jedi4ever/veewee#readme

--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ If you find yourself in a broken system state related to URL's that
 aren't resolving, there's a rake task to restart vagrant-dns. (You can
 list all rake tasks using `rake -T` or `rake -D`.)
 
+Upgrading
+---------
+
+Should you pull changes or switch branches, you'll very likely need to
+rerun the setup. At the very least, you should exit and re-enter the
+ariadne directory so that RVM will rerun the `.rvmrc` script, where some
+setup happens. You should then run `rake setup` again.
+
+If you want to be extra sure that you're running in the same environment
+that your version of Ariadne was tested on, rerun the RVM setup script,
+then open a new shell. (The version of RVM that Ariadne was tested on
+might vary, and this ensure you're using the exact same one.) You can
+also ensure that you're using the recommended version of Virtualbox,
+verifiable in this README.
+
 Notes
 -----
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ Notes
     site-install` when it detects that the docroot is already present, but
     setting the `clean=true` variable can tell chef to delete the docroot,
     and so the site will be rebuilt as it was during the first chef run.
+  - If your project's individual ariadne cookbook (for last-mile
+    configuration) has implemented it, you can specify the branch of
+    your project to build:
+
+        branch=123-story-description clean=true vagrant provision
+
+    Keep in mind that the `branch` flag might not have any effect in
+    some case, such as the default `example` project.
   - Several baseboxes that are presumed to work for Ariadne are
     available for use: `lucid32` & `lucid64`. (More may be added to
     `config/baseboxes.yml` in the future.)

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ task :setup do
 
   rel_dirs = %w{
     tmp/apt/cache/partial
+    tmp/drush/cache
     data/html
     data/make
     data/profiles

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,7 @@ Vagrant::Config.run do |config|
 
   # Share directories for project data and various caches
   config.vm.share_folder "apt-cache", "/var/cache/apt/archives", "#{current_dir}/tmp/apt/cache", :nfs => nfs_flag
+  config.vm.share_folder "drush-cache", "/home/vagrant/.drush/cache", "#{current_dir}/tmp/drush/cache", :nfs => nfs_flag
   config.vm.share_folder "html", "/mnt/www/html", "#{current_dir}/data/html", :nfs => nfs_flag
 
   config.vm.forward_port 80, 8080, :auto => true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ yml = YAML.load_file "#{current_dir}/config/config.yml"
 # Use 1) ENV variable, then 2) YAML config file
 basebox   = ENV['basebox']   ||= yml['basebox']
 project   = ENV['project']   ||= yml['project']
+branch    = ENV['branch']    ||= yml['branch']
 memory    = ENV['memory']    ||= yml['memory'].to_s
 cpu_count = ENV['cpu_count'] ||= yml['cpu_count'].to_s
 
@@ -23,6 +24,7 @@ end
 # Write property to YAML config file
 yml['basebox'] = basebox
 yml['project'] = project
+yml['branch'] = branch
 yml['memory'] = memory.to_i
 yml['cpu_count'] = cpu_count.to_i
 File.open("#{current_dir}/config/config.yml", 'w') { |f| YAML.dump(yml, f) }
@@ -92,6 +94,7 @@ Vagrant::Config.run do |config|
       },
       "ariadne" => {
         "project" => project,
+        "branch" => branch,
         "clean" => clean,
       }
     }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant::Config.run do |config|
   # Update Chef in VM to specific version before running provisioner
   config.vm.provision :shell do |shell|
     shell.path = "config/upgrade_chef.sh"
-    shell.args = "10.14.0" # Chef version
+    shell.args = "10.14.2" # Chef version
   end
 
   config.vm.provision :chef_solo do |chef|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant::Config.run do |config|
   # Update Chef in VM to specific version before running provisioner
   config.vm.provision :shell do |shell|
     shell.path = "config/upgrade_chef.sh"
-    shell.args = "10.12.0" # Chef version
+    shell.args = "10.14.0" # Chef version
   end
 
   config.vm.provision :chef_solo do |chef|

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,6 @@
 ---
 basebox: lucid64
 project: example
+branch: develop
 memory: 1000
 cpu_count: 2

--- a/cookbooks-override/ariadne/metadata.rb
+++ b/cookbooks-override/ariadne/metadata.rb
@@ -4,3 +4,5 @@ license          "GNU Public License 2.0"
 description      "Installs/Configures ariadne"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.0.1"
+
+depends          "bash"

--- a/cookbooks-override/ariadne/recipes/default.rb
+++ b/cookbooks-override/ariadne/recipes/default.rb
@@ -50,6 +50,10 @@ cookbook_file "/etc/ssh/ssh_config" do
   mode "0644"
 end
 
+bash_profile "login-dir" do
+  user "vagrant"
+end
+
 # SEE: http://stackoverflow.com/a/8191279/504018
 ruby_block "Give root access to the forwarded ssh agent" do
   block do

--- a/cookbooks-override/ariadne/templates/default/bash_profile-login-dir.sh.erb
+++ b/cookbooks-override/ariadne/templates/default/bash_profile-login-dir.sh.erb
@@ -1,0 +1,3 @@
+if [[ -d "/mnt/www/html/<%= node['ariadne']['project'] %>" ]]; then
+  cd /mnt/www/html/<%= node['ariadne']['project'] %>
+fi

--- a/cookbooks-override/phpcs/recipes/drupal_standard.rb
+++ b/cookbooks-override/phpcs/recipes/drupal_standard.rb
@@ -15,9 +15,6 @@ bash "copy-drupal-standard" do
   not_if "test -d $(pear config-get php_dir)/PHP/CodeSniffer/Standards/Drupal"
 end
 
-file "/home/vagrant/.bash_profile" do
-  owner "vagrant"
-  group "vagrant"
-  content "alias drupalcs='phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme'"
-  action :create_if_missing
+bash_profile "drupalcs-alias" do
+  user "vagrant"
 end

--- a/cookbooks-override/phpcs/templates/default/bash_profile-drupalcs-alias.sh.erb
+++ b/cookbooks-override/phpcs/templates/default/bash_profile-drupalcs-alias.sh.erb
@@ -1,0 +1,1 @@
+alias drupalcs='phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme'

--- a/cookbooks-projects/example/recipes/default.rb
+++ b/cookbooks-projects/example/recipes/default.rb
@@ -19,7 +19,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-require_recipe "ariadne::default"
+include_recipe "ariadne::default"
 
 project = "example"
 

--- a/roles/ariadne.json
+++ b/roles/ariadne.json
@@ -6,6 +6,7 @@
   "env_run_lists": {
   },
   "run_list": [
+    "recipe[bash]",
     "recipe[git]",
     "recipe[vim]",
     "role[acquia]",

--- a/roles/ariadne.json
+++ b/roles/ariadne.json
@@ -6,7 +6,6 @@
   "env_run_lists": {
   },
   "run_list": [
-    "recipe[bash]",
     "recipe[git]",
     "recipe[vim]",
     "role[acquia]",


### PR DESCRIPTION
When trying to set up an ariadne instance on @coord 's Windows Vista machine, we ran into some issues where rvm would install properly but fail to self-configure when `cd`-ing to the ariadne directory.

The exact error message is:

```
Error running 'autoreconf -is --force', please read $HOME/.rvm/log/ruby-1.9.3-p194-ariadne/yaml/autoreconf.log
```

---

Some relevant system information:
- Windows Vista Home Premium SP2 64-bit
- System ruby = Ruby 1.9.3-p194
- Cygwin 1.7.16-1
- rvm 1.14.7 (stable)
- bash version 4.1.10(4)-release (i686-pc-cygwin)

---

Apparently, rvm isn't as widely-supported on Windows machines. An alternative may be [Pik](https://github.com/vertiginous/pik). A helpful article on the differences / pros/cons between the two is _[Easily manage your rubies with RVM, Bundler and Pik](http://watirmelon.com/2011/01/17/easily-manage-your-rubies-with-rvm-bundler-and-pik/)_.
