### PR TITLE
Move install profile logic into generic recipe

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ yml = YAML.load_file "#{current_dir}/config/config.yml"
 # Use 1) ENV variable, then 2) YAML config file
 basebox   = ENV['basebox']   ||= yml['basebox']
 project   = ENV['project']   ||= yml['project']
+repo_url  = ENV['repo_url']  ||= yml['repo_url']
 branch    = ENV['branch']    ||= yml['branch']
 memory    = ENV['memory']    ||= yml['memory'].to_s
 cpu_count = ENV['cpu_count'] ||= yml['cpu_count'].to_s
@@ -24,6 +25,7 @@ end
 # Write property to YAML config file
 yml['basebox'] = basebox
 yml['project'] = project
+yml['repo_url'] = repo_url
 yml['branch'] = branch
 yml['memory'] = memory.to_i
 yml['cpu_count'] = cpu_count.to_i
@@ -80,7 +82,11 @@ Vagrant::Config.run do |config|
 
     # Set up basic environment
     chef.add_role "ariadne"
-    chef.add_recipe project
+    unless yml['repo_url'].empty?
+      chef.add_recipe "ariadne::install_profile"
+    else
+      chef.add_recipe project
+    end
 
     # Option so cookbooks can wipe files when set on command-line
     clean = true unless ENV['clean'].nil?
@@ -95,6 +101,7 @@ Vagrant::Config.run do |config|
       },
       "ariadne" => {
         "project" => project,
+        "repo_url" => repo_url,
         "branch" => branch,
         "clean" => clean,
       }

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,3 +4,7 @@ project: example
 branch: develop
 memory: 1000
 cpu_count: 2
+
+# If building an install profile according to Myplanet layout assumptions,
+# enter its repository URL here. (Otherwise, leave blank.)
+repo_url: ''

--- a/cookbooks-override/ariadne/recipes/install_profile.rb
+++ b/cookbooks-override/ariadne/recipes/install_profile.rb
@@ -1,0 +1,55 @@
+repo_url = node['ariadne']['repo_url']
+repo = node['ariadne']['project']
+site_url = "#{repo}.dev"
+branch = node['ariadne']['branch']
+
+web_app site_url do
+  cookbook "ariadne"
+  template "sites.conf.erb"
+  server_name site_url
+  server_aliases [ "*.#{site_url}" ]
+  docroot "/mnt/www/html/#{repo}"
+  port node['apache']['listen_ports'].to_a[0]
+end
+
+if node['ariadne']['clean']
+  execute "chmod -R 777 /mnt/www/html/#{repo}"
+  %W{
+    /vagrant/data/profiles/#{repo}
+    /mnt/www/html/#{repo}
+  }.each do |dir|
+    directory dir do
+      recursive true
+      action :delete
+      only_if "test -d #{dir}"
+    end
+  end
+end
+
+git "/vagrant/data/profiles/#{repo}" do
+  user "vagrant"
+  repository repo_url
+  reference branch
+  enable_submodules true
+  action :sync
+end
+
+bash "Building site..." do
+  user "vagrant"
+  group "vagrant"
+  cwd "/vagrant/data/profiles/#{repo}"
+  code <<-"EOH"
+    tmp/scripts/rerun/rerun 2ndlevel:build \
+      --build-file build-#{repo}.make \
+      --destination /mnt/www/html/#{repo} \
+      --revision #{branch} \
+      --project #{repo}
+  EOH
+  not_if "test -d /mnt/www/html/#{repo}"
+  environment({
+    'HOME' => '/home/vagrant',
+    'RERUN_MODULES' => "/vagrant/data/profiles/#{repo}/tmp/scripts/rerun-modules",
+  })
+  notifies :reload, "service[apache2]"
+  notifies :restart, "service[varnish]"
+end


### PR DESCRIPTION
Right now, we build all new Drupal sites at myplanet using install profile which all have the same general layout. As such, many of our cookbooks do very similar setup. We should move this into a general `ariadne::install_profile` recipe, so that these standard types of projects don't even need a special ariadne project cookbook to be "installed".

PR coming
