### PR TITLE
pear warning encountered during installation

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -25,8 +25,8 @@ cookbook "phpcs",
   :git => "https://github.com/myplanetdigital/chef-phpcs.git",
   :ref => "master"
 cookbook "phpunit",
-  :git => "https://github.com/msonnabaum/chef-phpunit.git",
-  :ref => "master"
+  :git => "https://github.com/myplanetdigital/chef-phpunit.git",
+  :ref => "GH-9-pear-errors"
 cookbook "postfix"
 cookbook "varnish"
 cookbook "vim"

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -32,14 +32,6 @@ GIT
       php (>= 0.0.0)
 
 GIT
-  remote: https://github.com/msonnabaum/chef-phpunit.git
-  ref: master
-  sha: 8379017c52c8187a53711286df1f4560b16eea20
-  specs:
-    phpunit (0.9.1)
-      php (>= 0.0.0)
-
-GIT
   remote: https://github.com/myplanetdigital/chef-bash.git
   ref: feature/bash_profile-resource
   sha: c3fb4df4d4692ccbc27ec1df365a057a81f387ab
@@ -69,6 +61,14 @@ GIT
   sha: d222847865abb4bbc40b217116433ed6419924f1
   specs:
     phpcs (1.0.0)
+      php (>= 0.0.0)
+
+GIT
+  remote: https://github.com/myplanetdigital/chef-phpunit.git
+  ref: GH-9-pear-errors
+  sha: e215dab712d0a4fb946b173c2b089688a8c7d617
+  specs:
+    phpunit (0.9.1)
       php (>= 0.0.0)
 
 GIT


### PR DESCRIPTION
//cc @fluxsauce 

```
[Mon, 25 Jun 2012 06:26:57 -0700] INFO: Start handlers complete.
[Mon, 25 Jun 2012 06:26:58 -0700] INFO: Missing gem 'mysql'
[Mon, 25 Jun 2012 06:26:58 -0700] WARN: Missing gem 'right_aws'
[Mon, 25 Jun 2012 06:26:58 -0700] INFO: Missing gem 'mysql'
[Mon, 25 Jun 2012 06:26:58 -0700] INFO: Could not find previously defined grants.sql resource
sh: 
pear: not found
```

Split off from #9

Rooted in this logic running during resource compilation phase of chef run (before pear or anything has been installed):
https://github.com/msonnabaum/chef-drush/blob/master/recipes/upgrade_pear.rb#L21
