### PR TITLE
xdebug Warning encountered during installation

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -31,8 +31,8 @@ cookbook "postfix"
 cookbook "varnish"
 cookbook "vim"
 cookbook "xdebug",
-  :git => "https://github.com/xforty/chef-xdebug.git",
-  :ref => "master"
+  :git => "https://github.com/myplanetdigital/chef-xdebug.git",
+  :ref => "GH-5-php_pear-zend-template"
 cookbook "xhprof",
   :git => "https://github.com/myplanetdigital/chef-xhprof.git",
   :ref => "GH-msonnabaum-3"

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -72,20 +72,20 @@ GIT
       php (>= 0.0.0)
 
 GIT
+  remote: https://github.com/myplanetdigital/chef-xdebug.git
+  ref: GH-5-php_pear-zend-template
+  sha: 9aefd6e62e91cace973867d6a1daf3ec8228d050
+  specs:
+    xdebug (0.0.1)
+      php (~> 1.1.0)
+
+GIT
   remote: https://github.com/myplanetdigital/chef-xhprof.git
   ref: GH-msonnabaum-3
   sha: 0d3690cd9e7ec1a469d30c5023130b5e2a29597d
   specs:
     xhprof (0.9.0)
       apt (>= 0.0.0)
-      php (>= 0.0.0)
-
-GIT
-  remote: https://github.com/xforty/chef-xdebug.git
-  ref: master
-  sha: e6745e79b451f692c56e979ab641412a6b2dacb3
-  specs:
-    xdebug (0.0.1)
       php (>= 0.0.0)
 
 DEPENDENCIES


### PR DESCRIPTION
```
[Mon, 25 Jun 2012 06:26:57 -0700] INFO: Start handlers complete.
[Mon, 25 Jun 2012 06:26:58 -0700] INFO: Missing gem 'mysql'
[Mon, 25 Jun 2012 06:26:58 -0700] WARN: Missing gem 'right_aws'
[Mon, 25 Jun 2012 06:26:58 -0700] INFO: Missing gem 'mysql'
[Mon, 25 Jun 2012 06:26:58 -0700] INFO: Could not find previously defined grants.sql resource
sh: 
pear: not found
```

```
[Mon, 25 Jun 2012 06:26:58 -0700] INFO: Processing package[git-core] action install (git::default line 21)
[Mon, 25 Jun 2012 06:32:13 -0700] INFO: Processing template[/etc/php5/conf.d/xdebug.ini] action create (xdebug::default line 32)
PHP Warning:  Xdebug MUST be loaded as a Zend extension in Unknown on line 0
```

was following the following from 10.7.4:

```

curl -L get.rvm.io | bash -s 1.14.1
source ~/.rvm/scripts/rvm
rvm reload
git clone https://github.com/myplanetdigital/ariadne.git new_vagrant_box
cd new_vagrant_box
bundle exec rake setup
  -- enter your password
bundle exec rake "init_project[myplanetdigital/ariadne-tap]"
project=tap bundle exec vagrant up
bundle exec rake restart_dns
```
