### PR TITLE
Use patched openssh cookbook for templates

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -7,6 +7,7 @@ cookbook "apache2"
 cookbook "apt"
 cookbook "bash",
   :git => "https://github.com/myplanetdigital/chef-bash.git",
+  # PR: https://github.com/mszoernyi/chef-bash/pull/1
   :ref => "feature/bash_profile-resource"
 cookbook "build-essential"
 cookbook "drush",
@@ -16,7 +17,12 @@ cookbook "git"
 cookbook "memcached"
 cookbook "mysql",
   :git => "https://github.com/myplanetdigital/chef-mysql.git",
+  # PR: https://github.com/opscode-cookbooks/mysql/pull/33
   :ref => "COOK-1610-bypass-preseed"
+cookbook "openssh",
+  :git => "https://github.com/patcon/chef-openssh.git",
+  # PR: https://github.com/opscode-cookbooks/openssh/pull/4
+  :ref => "patch-1"
 cookbook "percona",
   :git => "https://github.com/myplanetdigital/chef-percona.git",
   :ref => "master"
@@ -26,6 +32,7 @@ cookbook "phpcs",
   :ref => "master"
 cookbook "phpunit",
   :git => "https://github.com/myplanetdigital/chef-phpunit.git",
+  # PR: https://github.com/msonnabaum/chef-phpunit/pull/9
   :ref => "GH-9-pear-errors"
 cookbook "postfix"
 cookbook "varnish"
@@ -35,7 +42,9 @@ cookbook "webgrind",
   :ref => "master"
 cookbook "xdebug",
   :git => "https://github.com/myplanetdigital/chef-xdebug.git",
+  # PR: https://github.com/xforty/chef-xdebug/pull/5
   :ref => "GH-5-php_pear-zend-template"
 cookbook "xhprof",
   :git => "https://github.com/myplanetdigital/chef-xhprof.git",
+  # PR: https://github.com/msonnabaum/chef-xhprof/pull/5
   :ref => "GH-msonnabaum-3"

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -99,6 +99,13 @@ GIT
       apt (>= 0.0.0)
       php (>= 0.0.0)
 
+GIT
+  remote: https://github.com/patcon/chef-openssh.git
+  ref: patch-1
+  sha: 7e75bc590d0facdb9409c050660b52b681fb1afd
+  specs:
+    openssh (0.8.1)
+
 DEPENDENCIES
   apache2 (>= 0)
   apt (>= 0)
@@ -108,6 +115,7 @@ DEPENDENCIES
   git (>= 0)
   memcached (>= 0)
   mysql (>= 0)
+  openssh (>= 0)
   percona (>= 0)
   php (>= 0)
   phpcs (>= 0)

--- a/cookbooks-override/ariadne/files/default/ssh_config
+++ b/cookbooks-override/ariadne/files/default/ssh_config
@@ -1,4 +1,0 @@
-# Still warm about IP changes, but will automatically
-# add new host key signatures.
-Host *
-  StrictHostKeyChecking no

--- a/cookbooks-override/ariadne/recipes/default.rb
+++ b/cookbooks-override/ariadne/recipes/default.rb
@@ -42,14 +42,6 @@ file "/home/vagrant/.drush/drush.ini" do
   content "memory_limit = -1"
 end
 
-# Allow SSH and Git to work with github.com and git.*.com without manually
-# allowing host keys.
-cookbook_file "/etc/ssh/ssh_config" do
-  owner "root"
-  group "root"
-  mode "0644"
-end
-
 # Drop in bash_profile script so that ssh'ing leads to project docroot.
 bash_profile "login-dir" do
   user "vagrant"

--- a/roles/ariadne.json
+++ b/roles/ariadne.json
@@ -1,6 +1,14 @@
 {
   "name": "ariadne",
   "default_attributes": {
+    "openssh": {
+      "client": {
+        "strict_host_key_checking": "no"
+      },
+      "server": {
+        "permit_root_login": "no"
+      }
+    }
   },
   "json_class": "Chef::Role",
   "env_run_lists": {
@@ -8,6 +16,7 @@
   "run_list": [
     "recipe[git]",
     "recipe[vim]",
+    "recipe[openssh]",
     "role[acquia]",
     "role[dev_tools]",
     "recipe[ariadne::default]"


### PR DESCRIPTION
Lots of in-progress pull-requests that need help:
https://github.com/opscode-cookbooks/openssh/network
- lock down root with `ssh_config` template
- use `ssh_config` template rather than doing in `ariadne::default`
