### PR TITLE
Licencing of Oracle's VBox Extension Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Requirements
 
 *Tested versions in parentheses.*
 
-  - [Virtualbox and Extension Pack][vbox-downloads] [[Note]](#note-vbox) (v4.1.22)
+  - [Virtualbox][vbox-downloads] (v4.1.22)
   - [OSX GCC Installer][about-osx-gcc-installer] [[Note]](#note-gcc-installer)
   - [RVM][about-rvm] (v1.15.8) - Dealt with in "Quick Start" below
 
@@ -200,13 +200,6 @@ verifiable in this README.
 Notes
 -----
 
-<a name="note-vbox" />
-  - Be sure to install your version's matching "Extension Pack" from the
-    download page, as it contains the correct version of the [Virtualbox
-    Guest Additions][vbox-guest] package. This provides utlities intended to
-    be installed on any VM running on VBox. Thankfully, we'll be using a
-    [Vagrant plugin called vbguest][vagrant-vbguest], which will handle
-    copying this package into any VM that is out of date.
 <a name="note-gcc-installer" />
   - Xcode should also work (as opposed to just the OXS GCC installer),
     although it will not always be fully tested.
@@ -365,8 +358,6 @@ limitations under the License.
    [install-xdebug-emacs1]:   http://code.google.com/p/geben-on-emacs/source/browse/trunk/README
    [install-xdebug-emacs2]:   http://puregin.org/debugging-php-with-xdebug-and-emacs-on-mac-os-x
    [vbox-downloads]:          http://www.virtualbox.org/wiki/Downloads
-   [vbox-guest]:              http://www.virtualbox.org/manual/ch04.html#idp5980192
-   [vagrant-vbguest]:         https://github.com/dotless-de/vagrant-vbguest#readme
    [vagrant-dns]:             https://github.com/BerlinVagrant/vagrant-dns#readme
    [network-fix-ref]:         http://stackoverflow.com/questions/10378185/vagrant-a-better-to-way-to-reset-my-guest-vagrant-vms-network
    [install-zsh]:             http://jesperrasmussen.com/switching-bash-with-zsh


### PR DESCRIPTION
So the installation instructions for this Apache-licenced project (Ariadne) involve the installation of Oracle's VirtualBox Extension Pack. The licence for this software states:

'§ 2 Oracle grants you a personal, non-exclusive, non-transferable, limited license without fees to reproduce, install, execute, and use internally the Extension Pack on a Host Computer for your Personal Use, Educational Use, or Evaluation. [...] “Evaluation” means testing the Extension Pack for a reasonable period (that is, normally for a few weeks); after expiry of that term, you are no longer permitted to evaluate the Extension Pack.

§ 3 Any use beyond the provisions of § 2 is prohibited.'

This seems problematic for long-term development procedures and real-world scenarios.

How critical is the Extension Pack to the functioning of this project?
