### PR TITLE
Clarify README about required packages on ubuntu (12.04 to be precise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Notes
     although it will not always be fully tested.
   - <a name="note-ubuntu-reqs" /> If running Ubuntu, there are several required packages:
 
-        apt-get install build-essential libssl-dev libreadline5 zlib1g zlib1g-dev nfs-common nfs-kernel-server
+        apt-get install build-essential libssl-dev libreadline5 zlib1g zlib1g-dev nfs-common nfs-kernel-server libxml2 libxml2-dev libxslt1.1 libxslt1-dev
 
     And one more that depends on your Ubuntu codename version and architecture:
     - Precise 12.04: `apt-get install libreadline-gplv2-dev`

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Notes
     although it will not always be fully tested.
   - <a name="note-ubuntu-reqs" /> If running Ubuntu, there are several required packages:
 
-        apt-get install build-essential libssl-dev libreadline5 zlib1g zlib1g-dev nfs-common nfs-kernel-server libxml2 libxml2-dev libxslt1.1 libxslt1-dev
+        apt-get install build-essential libssl-dev libreadline5 zlib1g zlib1g-dev nfs-common nfs-kernel-server libxml2-dev libxslt1-dev
 
     And one more that depends on your Ubuntu codename version and architecture:
     - Precise 12.04: `apt-get install libreadline-gplv2-dev`


### PR DESCRIPTION
While following the README instrcutions I have been stopped at the 'vagrant up' command:

<pre>
$ vagrant up
/home/mikem/git/ariadne-deploy/Vagrantfile:10:in `<top (required)>': undefined method `load_file' for YAML:Module (NoMethodError)
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config/loader.rb:115:in `load'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config/loader.rb:115:in `block in procs_for_source'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config.rb:41:in `block in capture_configures'
    from <internal:prelude>:10:in `synchronize'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config.rb:36:in `capture_configures'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config/loader.rb:114:in `procs_for_source'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config/loader.rb:51:in `block in set'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config/loader.rb:45:in `each'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/config/loader.rb:45:in `set'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/environment.rb:377:in `block in load_config!'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/environment.rb:392:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/environment.rb:392:in `load_config!'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/lib/vagrant/environment.rb:327:in `load!'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.0.5/bin/vagrant:40:in `<top (required)>'
    from /opt/vagrant/bin/../embedded/gems/bin/vagrant:19:in `load'
    from /opt/vagrant/bin/../embedded/gems/bin/vagrant:19:in `<main>'
</pre>


Seems a bit strange to me that 'load_file' should generate an 'undefined method' error...

I'm using Vagrant 1.0.5 dpkg installed on Ubuntu 10.04 LTS x86_64 with VirtualBox 4.1.22. Vagrant and VBox are both functioning, as I can 'vagrant up' lucid32.box or lucid64.box, but when I try using the Ariadne Vagrantfile it fails as above.

Not sure if it's related but the only package from the README I did not install was libreadline-dplv2-dev because it is not in the 10.04 apt repository:

E: Couldn't find package libreadline-gplv2-dev
