### PR TITLE
Path to custom box broken after namespace change

### DIFF
--- a/config/baseboxes.yml
+++ b/config/baseboxes.yml
@@ -1,3 +1,3 @@
 # Only baseboxes that are presumed to work are present
 lucid32: http://files.vagrantup.com/lucid32.box
-lucid64: https://github.com/downloads/myplanetdigital/ariadne/lucid64.box
+lucid64: https://github.com/downloads/myplanetdigital/vagrant-ariadne/lucid64.box


### PR DESCRIPTION
Since this project was moved from `ariadne` to `vagrant-ariadne`, the URL to the lucid64 basebox specified in the `develop` branch's `config/baseboxes.yml` is wrong, and you get the following error when you try to `vagrant up`:

```
mparker17@mcomp5:Repositories/vagrant-ariadne % vagrant up
[ariadne] Box lucid64 was not found. Fetching box from specified URL...
[vagrant] Downloading with Vagrant::Downloaders::HTTP...
[vagrant] Downloading box: https://github.com/downloads/myplanetdigital/ariadne/lucid64.box
Bad status code: 404

Please verify that the box exists and is accessible. Also verify that
this computer is properly connected to the internet.
```
