### PR TITLE
chef doesn't like shortened git refs

### DIFF
--- a/roles/dev_tools.rb
+++ b/roles/dev_tools.rb
@@ -11,7 +11,7 @@ default_attributes({
     },
   },
   :phpcs => {
-    :coder_git_ref => "c43676c3909038",
+    :coder_git_ref => "c43676c3909038addcc75bc2c10ef35a1db1f368",
   },
   :phpunit => {
     :version => "3.6.10",


### PR DESCRIPTION
When running `vagrant up`  using custom lucid64 basebox, I get the following error:

```
[Sat, 10 Nov 2012 18:48:14 +0100] INFO: Processing php_pear[PHP_CodeSniffer] action install (phpcs::default line 22)
[Sat, 10 Nov 2012 18:48:16 +0100] INFO: Processing git[/tmp/vagrant-chef-1/coder] action sync (phpcs::drupal_standard line 3)

================================================================================
Error executing action `sync` on resource 'git[/tmp/vagrant-chef-1/coder]'
================================================================================

Chef::Exceptions::UnresolvableGitReference
------------------------------------------
Unable to parse SHA reference for 'c43676c3909038' in repository 'http://git.drupal.org/project/coder.git'. Verify your (case-sensitive) repository URL and revision.
`git ls-remote` output: 

Resource Declaration:
---------------------
# In /tmp/vagrant-chef-1/chef-solo-2/cookbooks/phpcs/recipes/drupal_standard.rb

  2: 
  3: git "#{Chef::Config[:file_cache_path]}/coder" do
  4:   repository "http://git.drupal.org/project/coder.git"
  5:   reference node['phpcs']['coder_git_ref']
  6:   action :sync
  7: end
  8: 

Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-2/cookbooks/phpcs/recipes/drupal_standard.rb:3:in `from_file'

git("/tmp/vagrant-chef-1/coder") do
  remote "origin"
  retry_delay 2
  cookbook_name :phpcs
  destination "/tmp/vagrant-chef-1/coder"
  retries 0
  repository "http://git.drupal.org/project/coder.git"
  action [:sync]
  revision "c43676c3909038"
  recipe_name "drupal_standard"
  provider Chef::Provider::Git
end

[Sat, 10 Nov 2012 18:48:17 +0100] ERROR: Running exception handlers
[Sat, 10 Nov 2012 18:48:17 +0100] ERROR: Exception handlers complete
[Sat, 10 Nov 2012 18:48:17 +0100] FATAL: Stacktrace dumped to /tmp/vagrant-chef-1/chef-stacktrace.out
[Sat, 10 Nov 2012 18:48:17 +0100] FATAL: Chef::Exceptions::UnresolvableGitReference: git[/tmp/vagrant-chef-1/coder] (phpcs::drupal_standard line 3) had an error: Chef::Exceptions::UnresolvableGitReference: Unable to parse SHA reference for 'c43676c3909038' in repository 'http://git.drupal.org/project/coder.git'. Verify your (case-sensitive) repository URL and revision.
`git ls-remote` output: 
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```

When I rgrep for the invalid SHA, I see it's referred to in `roles/dev_tools.rb`:

```
mparker17@mcomp5:Repositories/vagrant-ariadne % rgrep 'c43676c3909038'
roles/dev_tools.rb:14:    :coder_git_ref => "c43676c3909038",
```

The commit does appear to exist in the coder 7.x-2.x branch...

```
mparker17@mcomp5:Desktop/coder (7.x-2.x ✓) % git log | grep c43676c3909038
181:commit c43676c3909038addcc75bc2c10ef35a1db1f368
```

Perhaps this is a bug with Chef? I'll investigate.
