### PR TITLE
Fix syntax for Varnish 3.

### DIFF
--- a/cookbooks-override/varnish/templates/default/default.vcl.erb
+++ b/cookbooks-override/varnish/templates/default/default.vcl.erb
@@ -84,7 +84,7 @@ sub vcl_recv {
  
 sub vcl_hash {
   if (req.http.Cookie) {
-    set req.hash += req.http.Cookie;
+    hash_data(req.http.Cookie);
   }
 }
  
@@ -117,7 +117,7 @@ sub vcl_error {
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
   <html>
     <head>
-      <title>"} obj.status " " obj.response {"</title>
+      <title>" + obj.status + " " + obj.response + "</title>
       <style type="text/css">
       #page {width: 400px; padding: 10px; margin: 20px auto; border: 1px solid black; background-color: #FFF;}
       p {margin-left:20px;}
@@ -130,9 +130,9 @@ sub vcl_error {
     <p>We're very sorry, but the page could not be loaded properly. This should be fixed very soon, and we apologize for any inconvenience.</p>
     <hr />
     <h4>Debug Info:</h4>
-    <pre>Status: "} obj.status {"
-Response: "} obj.response {"
-XID: "} req.xid {"</pre>
+    <pre>Status: " + obj.status + "
+Response: " + obj.response + "
+XID: " + req.xid + "</pre>
       </div>
     </body>
    </html>


### PR DESCRIPTION
I know that this isn't the final solution, but it's a good place to start talking. Ubuntu 12.04 (which I know isn't the box you test with) uses Varnish 3. The `default.vcl.erb` template in `cookbooks-override/varnish/templates/default` assumes Varnish 2.

https://www.varnish-cache.org/docs/3.0/installation/upgrade.html was what I used to convert the syntax.

What's a reasonably platform-agnostic way to handle this?
