### PR TITLE
Simulate Acquia more closely with php-cgi

### DIFF
--- a/cookbooks-override/apache2/templates/default/mods/fcgid.conf.erb
+++ b/cookbooks-override/apache2/templates/default/mods/fcgid.conf.erb
@@ -1,0 +1,30 @@
+<IfModule mod_fcgid.c>
+  AddHandler fcgid-script .fcgi .php
+  # Where to look for the php.ini file?
+  DefaultInitEnv PHPRC        "/etc/php5/cgi"
+  # Maximum requests a process handles before it is terminated
+  MaxRequestsPerProcess       1000
+  # Maximum number of PHP processes
+  MaxProcessCount             10
+  # Number of seconds of idle time before a process is terminated
+  IPCCommTimeout              240
+  IdleTimeout                 240
+  #Or use this if you use the file above
+  FCGIWrapper /usr/bin/php-cgi .php
+
+
+
+  ServerLimit           500
+  StartServers            3
+  MinSpareThreads         3
+  MaxSpareThreads        10
+  ThreadsPerChild        10
+  MaxClients            300
+  MaxRequestsPerChild  1000
+</IfModule>
+
+<% if %w{ rhel fedora }.include?(node['platform_family']) -%>
+# Sane place to put sockets and shared memory file
+SocketPath run/mod_fcgid
+SharememPath run/mod_fcgid/fcgid_shm
+<% end -%>

--- a/cookbooks-override/ariadne/recipes/install_profile.rb
+++ b/cookbooks-override/ariadne/recipes/install_profile.rb
@@ -9,6 +9,7 @@ web_app site_url do
   server_name site_url
   server_aliases [ "*.#{site_url}" ]
   docroot "/mnt/www/html/#{repo}"
+  enable_cgi node.run_list.expand(node.chef_environment, 'disk').recipes.include?("apache2::mod_fcgid")
   port node['apache']['listen_ports'].to_a[0]
 end
 

--- a/cookbooks-override/ariadne/templates/default/drupal-site.conf.erb
+++ b/cookbooks-override/ariadne/templates/default/drupal-site.conf.erb
@@ -3,14 +3,14 @@
   ServerAlias <% @params[:server_aliases].each do |server_alias| %><%= server_alias %> <% end %>
   DocumentRoot <%= @params[:docroot] %>
   RewriteEngine On
-  
+
   <Directory <%= @params[:docroot] %>>
-    Options FollowSymLinks
+    Options FollowSymLinks <%= "ExecCGI" if @params[:enable_cgi] %>
     AllowOverride All
     Order allow,deny
     Allow from all
   </Directory>
-  
+
   <Directory />
     Options FollowSymLinks
     AllowOverride None

--- a/cookbooks-projects/example/recipes/default.rb
+++ b/cookbooks-projects/example/recipes/default.rb
@@ -61,6 +61,7 @@ web_app site do
   server_name site
   server_aliases [ "www.#{site}" ]
   docroot "/mnt/www/html/#{project}"
+  enable_cgi node.run_list.expand(node.chef_environment, 'disk').recipes.include?("apache2::mod_fcgid")
   notifies :reload, "service[apache2]"
 end
 

--- a/roles/README.md
+++ b/roles/README.md
@@ -17,7 +17,7 @@ calling deeper-level ones):
     roles                       # TYPE OF CONFIG
     └── ariadne                 # Role added by Vagrant
         └── acquia              # Configs to emulate Acquia
-        │   ├── apache2_mod_php
+        │   ├── apache2_php_cgi # Alt: apache2_mod_php
         │   ├── memcache
         │   ├── mysql           # Percona drop-in MySQL replacement
         │   ├── varnish

--- a/roles/acquia.rb
+++ b/roles/acquia.rb
@@ -1,7 +1,7 @@
 name "acquia"
 description "Install requirements to run Drupal application (not includding HTTP server and PHP, which should be provided in different ways)."
 run_list([
-  "role[apache2_mod_php]",
+  "role[apache2_php_cgi]",
   "role[memcache]",
   "role[mysql]",
   "role[varnish]",

--- a/roles/apache2_php_cgi.rb
+++ b/roles/apache2_php_cgi.rb
@@ -1,0 +1,37 @@
+name "apache2_mod_php"
+description "Configure php5.3 and apache2 with mod_php."
+run_list(
+  "recipe[php]",
+  "recipe[apache2]",
+  "recipe[apache2::mod_expires]",
+  "recipe[apache2::mod_rewrite]",
+  "recipe[apache2::mod_fcgid]",
+  "recipe[php::common_php_ini]"
+)
+default_attributes(
+  :php => {
+    :directives => {
+      :memory_limit => "160M"
+    }
+  },
+  :apache => {
+    :listen_ports => [ "80", "443" ],
+    :keepaliverequests => 10,
+    :prefork => {
+      :startservers => 2,
+      :minspareservers => 1,
+      :maxspareservers => 3,
+      :serverlimit => 4,
+      :maxclients => 4,
+      :maxrequestsperchild => 1000
+    },
+    :worker => {
+      :startservers => 2,
+      :maxclients => 128,
+      :minsparethreads => 16,
+      :maxsparethreads => 128,
+      :threadsperchild => 16,
+      :maxrequestsperchild => 0
+    }
+  }
+)

--- a/roles/apache2_php_cgi.rb
+++ b/roles/apache2_php_cgi.rb
@@ -1,5 +1,5 @@
 name "apache2_mod_php"
-description "Configure php5.3 and apache2 with mod_php."
+description "Configure php5.3 and apache2 with mod_fcgid."
 run_list(
   "recipe[php]",
   "recipe[apache2]",


### PR DESCRIPTION
Acquia uses php-cgi, not mod_php:
http://www.quora.com/Drupal-CMS/GetPantheon-vs-Omega8-vs-Acquia-pros-and-cons-of-each/answer/Barry-Jaspan/comment/1589243

We should have a role that uses apache2's `mod_fcgid` recipe rather than mod_php.
