### PR TITLE
Explore capistrano for deploys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem "chef"
+gem "drush-deploy"
 gem "knife-solo"
 gem "librarian"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,12 @@ GEM
     Platform (0.4.0)
     archive-tar-minitar (0.5.2)
     bunny (0.7.9)
+    capistrano (2.14.1)
+      highline
+      net-scp (>= 1.0.0)
+      net-sftp (>= 2.0.0)
+      net-ssh (>= 2.0.14)
+      net-ssh-gateway (>= 1.1.0)
     chef (10.18.2)
       bunny (>= 0.6.0, < 0.8.0)
       erubis
@@ -25,6 +31,10 @@ GEM
     childprocess (0.3.7)
       ffi (~> 1.0, >= 1.0.6)
     coderay (1.0.8)
+    drush-deploy (1.0.12)
+      capistrano (>= 2.12)
+      php_serialize (>= 1.2)
+      railsless-deploy (>= 1.0.2)
     erubis (2.7.0)
     ffi (1.3.1)
     foodcritic (1.7.0)
@@ -65,6 +75,8 @@ GEM
     moneta (0.6.0)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
+    net-sftp (2.0.5)
+      net-ssh (>= 2.0.9)
     net-ssh (2.2.2)
     net-ssh-gateway (1.1.0)
       net-ssh (>= 1.99.1)
@@ -81,6 +93,7 @@ GEM
       systemu
       yajl-ruby
     open4 (1.3.0)
+    php_serialize (1.2)
     polyglot (0.3.3)
     popen4 (0.1.2)
       Platform (>= 0.4.0)
@@ -89,6 +102,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.7.1)
       slop (>= 2.4.4, < 3)
+    railsless-deploy (1.0.2)
     rak (1.4)
     rake (10.0.3)
     rest-client (1.6.7)
@@ -131,6 +145,7 @@ PLATFORMS
 
 DEPENDENCIES
   chef
+  drush-deploy
   foodcritic
   knife-solo
   librarian

--- a/config/Capfile
+++ b/config/Capfile
@@ -1,0 +1,14 @@
+require 'drush_deploy'
+
+module UseScpForDeployment
+  def self.included(base)
+    base.send(:alias_method, :old_upload, :upload)
+    base.send(:alias_method, :upload,     :new_upload)
+  end
+
+  def new_upload(from, to, options = {})
+    old_upload(from, to, options.merge!(:via => :scp))
+  end
+end
+
+Capistrano::Configuration.send(:include, UseScpForDeployment)


### PR DESCRIPTION
Currently we're deploying with Chef itself. It might make more sense to deploy with Capistrano, with the idea being that we can deploy to the configured vagrant VM in the same way that we would deploy to a remote server.

So basically, use Chef to set up the server environment from scratch, but use a real deploy tool to send the set up the actual Drupal app.

Definitely requires way more thought, but just wanted to throw it out there
